### PR TITLE
Replace print statement for printLog

### DIFF
--- a/lib/src/user_location_layer.dart
+++ b/lib/src/user_location_layer.dart
@@ -120,7 +120,7 @@ class _MapsPluginLayerState extends State<MapsPluginLayer>
           }
           //widget.options.markers.clear();
 
-          print("Direction : " + (_direction ?? 0).toString());
+          printLog("Direction : " + (_direction ?? 0).toString());
 
           _locationMarker = Marker(
               height: 60.0,


### PR DESCRIPTION
Don't log `onLocationChanged` updates unless verbose is set to true i.e. use `printLog`